### PR TITLE
Add .gitignore with common binary and temp file patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Ignore OS-generated files
+.DS_Store
+Thumbs.db
+
+# Ignore backup files
+*~
+*.bak
+
+# Ignore PDF and other large binaries
+*.pdf
+*.zip
+*.tar.gz
+*.tgz
+*.rar
+*.7z
+*.iso
+*.bin
+*.exe
+*.dll
+
+# Ignore temporary artifacts
+*.tmp
+*.log
+
+# Node modules or Python caches (in case)
+node_modules/
+__pycache__/


### PR DESCRIPTION
## Summary
- add .gitignore at repo root to exclude common backup files and large binary data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846523cc52083299ec0a33d8371d296