### PR TITLE
Add skeleton ROS catkin workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,14 @@ https://www.facebook.com/yahboomcar/
 ### Technical support email: 
 support@yahboom.com
 
+
+## Building the workspace
+
+This repository includes a minimal ROS catkin workspace located in `catkin_ws`.
+To build all packages run:
+
+```bash
+cd catkin_ws
+catkin_make
+source devel/setup.bash
+```

--- a/catkin_ws/src/CMakeLists.txt
+++ b/catkin_ws/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+cmake_minimum_required(VERSION 3.0.2)

--- a/catkin_ws/src/interfaces/CMakeLists.txt
+++ b/catkin_ws/src/interfaces/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(interfaces)
+find_package(catkin REQUIRED)
+catkin_package()
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)

--- a/catkin_ws/src/interfaces/package.xml
+++ b/catkin_ws/src/interfaces/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>interfaces</name>
+  <version>0.0.0</version>
+  <description>Placeholder package for interfaces.</description>
+  <maintainer email="todo@example.com">TODO</maintainer>
+  <license>TODO</license>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/catkin_ws/src/manipulation/CMakeLists.txt
+++ b/catkin_ws/src/manipulation/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(manipulation)
+find_package(catkin REQUIRED)
+catkin_package()
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)

--- a/catkin_ws/src/manipulation/package.xml
+++ b/catkin_ws/src/manipulation/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>manipulation</name>
+  <version>0.0.0</version>
+  <description>Placeholder package for manipulation.</description>
+  <maintainer email="todo@example.com">TODO</maintainer>
+  <license>TODO</license>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/catkin_ws/src/navigation/CMakeLists.txt
+++ b/catkin_ws/src/navigation/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(navigation)
+find_package(catkin REQUIRED)
+catkin_package()
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)

--- a/catkin_ws/src/navigation/package.xml
+++ b/catkin_ws/src/navigation/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>navigation</name>
+  <version>0.0.0</version>
+  <description>Placeholder package for navigation.</description>
+  <maintainer email="todo@example.com">TODO</maintainer>
+  <license>TODO</license>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/catkin_ws/src/perception/CMakeLists.txt
+++ b/catkin_ws/src/perception/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(perception)
+find_package(catkin REQUIRED)
+catkin_package()
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)

--- a/catkin_ws/src/perception/package.xml
+++ b/catkin_ws/src/perception/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>perception</name>
+  <version>0.0.0</version>
+  <description>Placeholder package for perception.</description>
+  <maintainer email="todo@example.com">TODO</maintainer>
+  <license>TODO</license>
+  <buildtool_depend>catkin</buildtool_depend>
+</package>


### PR DESCRIPTION
## Summary
- set up a `catkin_ws` workspace with top-level `CMakeLists.txt`
- add placeholder packages: perception, navigation, manipulation and interfaces
- document build steps in the main README

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y ros-desktop-full` *(fails: package has no installation candidate)*
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464b705da483298339a5e0db737c17