### PR TITLE
Add phase docs with roadmap summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Junk o Matic Transbot
+
+## Project Roadmap
+- [Phase 1 Overview](docs/phase1_overview.md)
+- [Phase 2 Enhancements](docs/phase2_enhancements.md)
+- [Phase 3 Deployment](docs/phase3_deployment.md)

--- a/docs/phase1_overview.md
+++ b/docs/phase1_overview.md
@@ -1,0 +1,10 @@
+# Phase 1 Overview
+
+## Objectives
+- Establish baseline tele-operation to manually control the Transbot.
+- Validate core mobility functions and remote connectivity.
+
+## Key Outputs
+- Functional tele-op controller scripts.
+- Documentation showing how to launch tele-op mode from a laptop or mobile device.
+- Initial feedback on communication latency and range.

--- a/docs/phase2_enhancements.md
+++ b/docs/phase2_enhancements.md
@@ -1,0 +1,10 @@
+# Phase 2 Enhancements
+
+## Objectives
+- Develop hardware drivers for sensors and actuators.
+- Integrate additional navigation features and refine tele-op controls.
+
+## Key Outputs
+- Stable ROS packages for motor, lidar, and camera drivers.
+- Calibration procedures for new sensors.
+- Updated user guides covering hardware setup and troubleshooting.

--- a/docs/phase3_deployment.md
+++ b/docs/phase3_deployment.md
@@ -1,0 +1,10 @@
+# Phase 3 Deployment
+
+## Objectives
+- Prepare the Transbot for field trials and on-site operations.
+- Finalize automation routines and integrate cloud services for data logging.
+
+## Key Outputs
+- Deployment scripts for autonomous startup.
+- Test reports from real-world litter collection trials.
+- Guidelines for scaling to multiple robots and managing remote updates.


### PR DESCRIPTION
## Summary
- document Phase 1 objectives like tele-op
- document Phase 2 hardware enhancements
- document Phase 3 deployment plans
- link new docs from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f1c8a1988329a9d140884d9b56f2