### PR TITLE
Add teleop package and docs

### DIFF
--- a/catkin_ws/src/teleop/CMakeLists.txt
+++ b/catkin_ws/src/teleop/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(teleop)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+catkin_install_python(PROGRAMS scripts/teleop_keyboard.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/catkin_ws/src/teleop/launch/teleop.launch
+++ b/catkin_ws/src/teleop/launch/teleop.launch
@@ -1,0 +1,3 @@
+<launch>
+  <node pkg="teleop" type="teleop_keyboard.py" name="teleop_keyboard" output="screen"/>
+</launch>

--- a/catkin_ws/src/teleop/package.xml
+++ b/catkin_ws/src/teleop/package.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>teleop</name>
+  <version>0.0.0</version>
+  <description>Simple teleop package for keyboard driving.</description>
+  <maintainer email="todo@example.com">TODO</maintainer>
+  <license>TODO</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+</package>

--- a/catkin_ws/src/teleop/scripts/teleop_keyboard.py
+++ b/catkin_ws/src/teleop/scripts/teleop_keyboard.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+import rospy
+from geometry_msgs.msg import Twist
+import sys, select, termios, tty
+
+msg = """
+Reading from the keyboard and Publishing to Twist!
+---------------------------
+Use WASD keys to control the robot
+CTRL-C to quit
+"""
+moveBindings = {
+    'w':(1,0),
+    's':(-1,0),
+    'a':(0,1),
+    'd':(0,-1),
+}
+
+def getKey():
+    tty.setraw(sys.stdin.fileno())
+    rlist, _, _ = select.select([sys.stdin], [], [], 0.1)
+    if rlist:
+        key = sys.stdin.read(1)
+    else:
+        key = ''
+    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
+    return key
+
+if __name__ == '__main__':
+    settings = termios.tcgetattr(sys.stdin)
+    rospy.init_node('teleop_keyboard')
+    pub = rospy.Publisher('cmd_vel', Twist, queue_size=1)
+    speed = rospy.get_param("~speed", 0.2)
+    turn = rospy.get_param("~turn", 1.0)
+    try:
+        print(msg)
+        while not rospy.is_shutdown():
+            key = getKey()
+            if key in moveBindings:
+                x, th = moveBindings[key]
+            elif key == '\x03':
+                break
+            else:
+                x = 0
+                th = 0
+            twist = Twist()
+            twist.linear.x = x * speed
+            twist.angular.z = th * turn
+            pub.publish(twist)
+    except rospy.ROSInterruptException:
+        pass
+    finally:
+        twist = Twist()
+        pub.publish(twist)
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)

--- a/docs/phase1_overview.md
+++ b/docs/phase1_overview.md
@@ -1,0 +1,3 @@
+# Phase 1 Overview
+
+This document outlines the initial setup steps for the robot. See [Teleop Setup](teleop_setup.md) for instructions on manually driving the robot.

--- a/docs/teleop_setup.md
+++ b/docs/teleop_setup.md
@@ -1,0 +1,17 @@
+# Teleop Setup
+
+This package allows you to drive the robot in Gazebo or on real hardware using your keyboard.
+
+## Build
+```
+cd catkin_ws
+catkin_make
+```
+
+## Run
+```
+source devel/setup.bash
+roslaunch teleop teleop.launch
+```
+
+Use the `W`, `A`, `S`, `D` keys to move the robot and `CTRL-C` to stop.


### PR DESCRIPTION
## Summary
- add teleop ROS package with simple keyboard control
- document how to run teleop
- link teleop docs from phase1 overview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f1cd9de88329828a4fae1a2268be