### PR TITLE
Add perception demo node

### DIFF
--- a/catkin_ws/src/perception/CMakeLists.txt
+++ b/catkin_ws/src/perception/CMakeLists.txt
@@ -5,3 +5,8 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+catkin_install_python(PROGRAMS
+  scripts/dummy_classifier.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/catkin_ws/src/perception/launch/perception_demo.launch
+++ b/catkin_ws/src/perception/launch/perception_demo.launch
@@ -1,0 +1,3 @@
+<launch>
+    <node pkg="perception" type="dummy_classifier.py" name="dummy_classifier" output="screen"/>
+</launch>

--- a/catkin_ws/src/perception/package.xml
+++ b/catkin_ws/src/perception/package.xml
@@ -6,4 +6,7 @@
   <maintainer email="todo@example.com">TODO</maintainer>
   <license>TODO</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 </package>

--- a/catkin_ws/src/perception/scripts/dummy_classifier.py
+++ b/catkin_ws/src/perception/scripts/dummy_classifier.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import rospy
+from sensor_msgs.msg import Image
+from std_msgs.msg import String
+
+class DummyClassifier:
+    def __init__(self):
+        self.publisher = rospy.Publisher('/perception/classification', String, queue_size=10)
+        self.subscriber = rospy.Subscriber('/camera/image_raw', Image, self.callback)
+
+    def callback(self, msg):
+        # Always publish the same label as a placeholder
+        result = String(data='unknown object')
+        self.publisher.publish(result)
+
+if __name__ == '__main__':
+    rospy.init_node('dummy_classifier')
+    DummyClassifier()
+    rospy.spin()

--- a/docs/perception_demo.md
+++ b/docs/perception_demo.md
@@ -1,0 +1,16 @@
+# Perception Demo
+
+This demo runs a simple node that subscribes to camera images and publishes a dummy classification result.
+
+## Running the Demo
+
+1. Build the workspace if you haven't already:
+   ```bash
+   cd ~/catkin_ws
+   catkin_make
+   ```
+2. Launch the demo:
+   ```bash
+   roslaunch perception perception_demo.launch
+   ```
+   The node listens on `/camera/image_raw` and publishes a constant label on `/perception/classification`.

--- a/docs/phase1_overview.md
+++ b/docs/phase1_overview.md
@@ -1,0 +1,3 @@
+# Phase 1 Overview
+
+The perception stack starts with a very simple example. See [Perception Demo](perception_demo.md) for instructions on running a dummy image classifier that subscribes to the camera stream.


### PR DESCRIPTION
## Summary
- add dummy image classification node in `perception`
- install node through CMake
- expose launch file
- document the perception demo
- link demo from phase1 overview

## Testing
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f1cf4e048329b1e6783680551865