### PR TITLE
Add ROS hardware interface stubs

### DIFF
--- a/catkin_ws/src/interfaces/CMakeLists.txt
+++ b/catkin_ws/src/interfaces/CMakeLists.txt
@@ -5,3 +5,8 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+catkin_install_python(PROGRAMS
+  scripts/imu_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/catkin_ws/src/interfaces/package.xml
+++ b/catkin_ws/src/interfaces/package.xml
@@ -3,7 +3,7 @@
   <name>interfaces</name>
   <version>0.0.0</version>
   <description>Placeholder package for interfaces.</description>
-  <maintainer email="todo@example.com">TODO</maintainer>
-  <license>TODO</license>
+  <maintainer email="rob@yengo.com">Robert Yengo</maintainer>
+  <license>MIT</license>
   <buildtool_depend>catkin</buildtool_depend>
 </package>

--- a/catkin_ws/src/interfaces/scripts/imu_node.py
+++ b/catkin_ws/src/interfaces/scripts/imu_node.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import rospy
+from sensor_msgs.msg import Imu
+
+class ImuNode:
+    def __init__(self):
+        self.publisher = rospy.Publisher('imu/data_raw', Imu, queue_size=10)
+        self.rate = rospy.Rate(10)
+
+    def run(self):
+        rospy.loginfo('IMU node started')
+        msg = Imu()
+        while not rospy.is_shutdown():
+            # TODO: populate IMU message fields from actual sensor
+            self.publisher.publish(msg)
+            self.rate.sleep()
+
+if __name__ == '__main__':
+    rospy.init_node('imu_node')
+    node = ImuNode()
+    node.run()

--- a/catkin_ws/src/manipulation/CMakeLists.txt
+++ b/catkin_ws/src/manipulation/CMakeLists.txt
@@ -5,3 +5,8 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+catkin_install_python(PROGRAMS
+  scripts/arm_driver_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/catkin_ws/src/manipulation/package.xml
+++ b/catkin_ws/src/manipulation/package.xml
@@ -3,7 +3,7 @@
   <name>manipulation</name>
   <version>0.0.0</version>
   <description>Placeholder package for manipulation.</description>
-  <maintainer email="todo@example.com">TODO</maintainer>
-  <license>TODO</license>
+  <maintainer email="rob@yengo.com">Robert Yengo</maintainer>
+  <license>MIT</license>
   <buildtool_depend>catkin</buildtool_depend>
 </package>

--- a/catkin_ws/src/manipulation/scripts/arm_driver_node.py
+++ b/catkin_ws/src/manipulation/scripts/arm_driver_node.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+import rospy
+from std_msgs.msg import String
+
+class ArmDriverNode:
+    def __init__(self):
+        self.command_sub = rospy.Subscriber('arm/command', String, self.command_cb)
+        rospy.loginfo('Arm driver node initialized')
+
+    def command_cb(self, msg):
+        # TODO: send command to physical arm controller
+        rospy.loginfo('Received arm command: %s', msg.data)
+
+if __name__ == '__main__':
+    rospy.init_node('arm_driver_node')
+    node = ArmDriverNode()
+    rospy.spin()

--- a/catkin_ws/src/navigation/CMakeLists.txt
+++ b/catkin_ws/src/navigation/CMakeLists.txt
@@ -5,3 +5,8 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+catkin_install_python(PROGRAMS
+  scripts/wheel_encoder_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/catkin_ws/src/navigation/package.xml
+++ b/catkin_ws/src/navigation/package.xml
@@ -3,7 +3,7 @@
   <name>navigation</name>
   <version>0.0.0</version>
   <description>Placeholder package for navigation.</description>
-  <maintainer email="todo@example.com">TODO</maintainer>
-  <license>TODO</license>
+  <maintainer email="rob@yengo.com">Robert Yengo</maintainer>
+  <license>MIT</license>
   <buildtool_depend>catkin</buildtool_depend>
 </package>

--- a/catkin_ws/src/navigation/scripts/wheel_encoder_node.py
+++ b/catkin_ws/src/navigation/scripts/wheel_encoder_node.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import rospy
+from nav_msgs.msg import Odometry
+
+class WheelEncoderNode:
+    def __init__(self):
+        self.publisher = rospy.Publisher('wheel/odometry', Odometry, queue_size=10)
+        self.rate = rospy.Rate(10)
+
+    def run(self):
+        rospy.loginfo('Wheel encoder node started')
+        msg = Odometry()
+        while not rospy.is_shutdown():
+            # TODO: compute odometry from encoder ticks
+            self.publisher.publish(msg)
+            self.rate.sleep()
+
+if __name__ == '__main__':
+    rospy.init_node('wheel_encoder_node')
+    node = WheelEncoderNode()
+    node.run()

--- a/docs/phase2_enhancements.md
+++ b/docs/phase2_enhancements.md
@@ -1,0 +1,26 @@
+# Phase 2 Enhancements
+
+This phase introduces hardware interface nodes and message definitions for new sensors and actuators.
+
+## Wheel Encoder Node (`navigation` package)
+- **Node Name**: `wheel_encoder_node`
+- **Publishes**: `nav_msgs/Odometry` on `wheel/odometry`
+- **Parameters**:
+  - `wheel_radius` (double): radius of the drive wheels in meters.
+  - `ticks_per_rev` (int): encoder ticks per wheel revolution.
+
+## IMU Node (`interfaces` package)
+- **Node Name**: `imu_node`
+- **Publishes**: `sensor_msgs/Imu` on `imu/data_raw`
+- **Parameters**:
+  - `port` (string): serial device for the IMU.
+  - `frame_id` (string): TF frame for the IMU data.
+
+## Arm Driver Node (`manipulation` package)
+- **Node Name**: `arm_driver_node`
+- **Subscribes**: `std_msgs/String` on `arm/command`
+- **Parameters**:
+  - `baudrate` (int): serial speed for the arm controller.
+  - `port` (string): serial device for the arm.
+
+These stubs provide a starting point for integrating real hardware drivers and should be expanded with actual sensor handling logic.


### PR DESCRIPTION
## Summary
- add wheel encoder, IMU, and arm driver node stubs
- install new Python nodes in respective packages
- fill in maintainer and license information
- document Phase 2 ROS interfaces

## Testing
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f1d0a5b0832984bdfafe241a5070