### PR TITLE
Expand packages with sample nodes

### DIFF
--- a/catkin_ws/src/interfaces/CMakeLists.txt
+++ b/catkin_ws/src/interfaces/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(interfaces)
-find_package(catkin REQUIRED)
+
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs)
+
 catkin_package()
+
 include_directories(
   ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(${PROJECT_NAME}_node src/interfaces_node.cpp)
+target_link_libraries(${PROJECT_NAME}_node ${catkin_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME}_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/catkin_ws/src/interfaces/package.xml
+++ b/catkin_ws/src/interfaces/package.xml
@@ -3,7 +3,14 @@
   <name>interfaces</name>
   <version>0.0.0</version>
   <description>Placeholder package for interfaces.</description>
-  <maintainer email="todo@example.com">TODO</maintainer>
-  <license>TODO</license>
-  <buildtool_depend>catkin</buildtool_depend>
+  <maintainer email="robert@example.com">Robert Yengo</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend version_eq="0.8.10">catkin</buildtool_depend>
+  <build_depend version_eq="1.15.11">roscpp</build_depend>
+  <build_depend version_eq="1.15.11">rospy</build_depend>
+  <build_depend version_eq="0.5.11">std_msgs</build_depend>
+  <exec_depend version_eq="1.15.11">roscpp</exec_depend>
+  <exec_depend version_eq="1.15.11">rospy</exec_depend>
+  <exec_depend version_eq="0.5.11">std_msgs</exec_depend>
 </package>

--- a/catkin_ws/src/interfaces/src/interfaces_node.cpp
+++ b/catkin_ws/src/interfaces/src/interfaces_node.cpp
@@ -1,0 +1,12 @@
+#include <ros/ros.h>
+int main(int argc, char** argv){
+  ros::init(argc, argv, "interfaces_node");
+  ros::NodeHandle nh;
+  ROS_INFO("Interfaces node running");
+  ros::Rate r(1);
+  while (ros::ok()){
+    ros::spinOnce();
+    r.sleep();
+  }
+  return 0;
+}

--- a/catkin_ws/src/manipulation/CMakeLists.txt
+++ b/catkin_ws/src/manipulation/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(manipulation)
-find_package(catkin REQUIRED)
+
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs)
+
 catkin_package()
+
 include_directories(
   ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(${PROJECT_NAME}_node src/manipulation_node.cpp)
+target_link_libraries(${PROJECT_NAME}_node ${catkin_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME}_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/catkin_ws/src/manipulation/package.xml
+++ b/catkin_ws/src/manipulation/package.xml
@@ -3,7 +3,14 @@
   <name>manipulation</name>
   <version>0.0.0</version>
   <description>Placeholder package for manipulation.</description>
-  <maintainer email="todo@example.com">TODO</maintainer>
-  <license>TODO</license>
-  <buildtool_depend>catkin</buildtool_depend>
+  <maintainer email="robert@example.com">Robert Yengo</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend version_eq="0.8.10">catkin</buildtool_depend>
+  <build_depend version_eq="1.15.11">roscpp</build_depend>
+  <build_depend version_eq="1.15.11">rospy</build_depend>
+  <build_depend version_eq="0.5.11">std_msgs</build_depend>
+  <exec_depend version_eq="1.15.11">roscpp</exec_depend>
+  <exec_depend version_eq="1.15.11">rospy</exec_depend>
+  <exec_depend version_eq="0.5.11">std_msgs</exec_depend>
 </package>

--- a/catkin_ws/src/manipulation/src/manipulation_node.cpp
+++ b/catkin_ws/src/manipulation/src/manipulation_node.cpp
@@ -1,0 +1,12 @@
+#include <ros/ros.h>
+int main(int argc, char** argv){
+  ros::init(argc, argv, "manipulation_node");
+  ros::NodeHandle nh;
+  ROS_INFO("Manipulation node running");
+  ros::Rate r(1);
+  while (ros::ok()){
+    ros::spinOnce();
+    r.sleep();
+  }
+  return 0;
+}

--- a/catkin_ws/src/navigation/CMakeLists.txt
+++ b/catkin_ws/src/navigation/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(navigation)
-find_package(catkin REQUIRED)
+
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs)
+
 catkin_package()
+
 include_directories(
   ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(${PROJECT_NAME}_node src/navigation_node.cpp)
+target_link_libraries(${PROJECT_NAME}_node ${catkin_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME}_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/catkin_ws/src/navigation/package.xml
+++ b/catkin_ws/src/navigation/package.xml
@@ -3,7 +3,14 @@
   <name>navigation</name>
   <version>0.0.0</version>
   <description>Placeholder package for navigation.</description>
-  <maintainer email="todo@example.com">TODO</maintainer>
-  <license>TODO</license>
-  <buildtool_depend>catkin</buildtool_depend>
+  <maintainer email="robert@example.com">Robert Yengo</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend version_eq="0.8.10">catkin</buildtool_depend>
+  <build_depend version_eq="1.15.11">roscpp</build_depend>
+  <build_depend version_eq="1.15.11">rospy</build_depend>
+  <build_depend version_eq="0.5.11">std_msgs</build_depend>
+  <exec_depend version_eq="1.15.11">roscpp</exec_depend>
+  <exec_depend version_eq="1.15.11">rospy</exec_depend>
+  <exec_depend version_eq="0.5.11">std_msgs</exec_depend>
 </package>

--- a/catkin_ws/src/navigation/src/navigation_node.cpp
+++ b/catkin_ws/src/navigation/src/navigation_node.cpp
@@ -1,0 +1,12 @@
+#include <ros/ros.h>
+int main(int argc, char** argv){
+  ros::init(argc, argv, "navigation_node");
+  ros::NodeHandle nh;
+  ROS_INFO("Navigation node running");
+  ros::Rate r(1);
+  while (ros::ok()){
+    ros::spinOnce();
+    r.sleep();
+  }
+  return 0;
+}

--- a/catkin_ws/src/perception/CMakeLists.txt
+++ b/catkin_ws/src/perception/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(perception)
-find_package(catkin REQUIRED)
+
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs)
+
 catkin_package()
+
 include_directories(
   ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(${PROJECT_NAME}_node src/perception_node.cpp)
+target_link_libraries(${PROJECT_NAME}_node ${catkin_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME}_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/catkin_ws/src/perception/package.xml
+++ b/catkin_ws/src/perception/package.xml
@@ -3,7 +3,14 @@
   <name>perception</name>
   <version>0.0.0</version>
   <description>Placeholder package for perception.</description>
-  <maintainer email="todo@example.com">TODO</maintainer>
-  <license>TODO</license>
-  <buildtool_depend>catkin</buildtool_depend>
+  <maintainer email="robert@example.com">Robert Yengo</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend version_eq="0.8.10">catkin</buildtool_depend>
+  <build_depend version_eq="1.15.11">roscpp</build_depend>
+  <build_depend version_eq="1.15.11">rospy</build_depend>
+  <build_depend version_eq="0.5.11">std_msgs</build_depend>
+  <exec_depend version_eq="1.15.11">roscpp</exec_depend>
+  <exec_depend version_eq="1.15.11">rospy</exec_depend>
+  <exec_depend version_eq="0.5.11">std_msgs</exec_depend>
 </package>

--- a/catkin_ws/src/perception/src/perception_node.cpp
+++ b/catkin_ws/src/perception/src/perception_node.cpp
@@ -1,0 +1,12 @@
+#include <ros/ros.h>
+int main(int argc, char** argv){
+  ros::init(argc, argv, "perception_node");
+  ros::NodeHandle nh;
+  ROS_INFO("Perception node running");
+  ros::Rate r(1);
+  while (ros::ok()){
+    ros::spinOnce();
+    r.sleep();
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add simple ROS nodes for perception, manipulation, navigation and interfaces
- set maintainer and license info
- pin dependency versions and list build/exec packages
- build and install executables in CMake

## Testing
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f284e21c83298fbccae1c4488c84