### PR TITLE
Add sample rostests for packages

### DIFF
--- a/catkin_ws/src/interfaces/CMakeLists.txt
+++ b/catkin_ws/src/interfaces/CMakeLists.txt
@@ -5,3 +5,8 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest(test/test_basic.test)
+endif()

--- a/catkin_ws/src/interfaces/package.xml
+++ b/catkin_ws/src/interfaces/package.xml
@@ -6,4 +6,5 @@
   <maintainer email="todo@example.com">TODO</maintainer>
   <license>TODO</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>rostest</test_depend>
 </package>

--- a/catkin_ws/src/interfaces/test/sample_data.txt
+++ b/catkin_ws/src/interfaces/test/sample_data.txt
@@ -1,0 +1,1 @@
+sample data

--- a/catkin_ws/src/interfaces/test/test_basic.py
+++ b/catkin_ws/src/interfaces/test/test_basic.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+import unittest
+
+class BasicTest(unittest.TestCase):
+    def test_read_sample(self):
+        path = os.path.join(os.path.dirname(__file__), "sample_data.txt")
+        with open(path) as f:
+            data = f.read().strip()
+        self.assertEqual(data, "sample data")
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun('interfaces', 'basic_test', BasicTest)

--- a/catkin_ws/src/interfaces/test/test_basic.test
+++ b/catkin_ws/src/interfaces/test/test_basic.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="basic_test" pkg="interfaces" type="test_basic.py" />
+</launch>

--- a/catkin_ws/src/manipulation/CMakeLists.txt
+++ b/catkin_ws/src/manipulation/CMakeLists.txt
@@ -5,3 +5,8 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest(test/test_basic.test)
+endif()

--- a/catkin_ws/src/manipulation/package.xml
+++ b/catkin_ws/src/manipulation/package.xml
@@ -6,4 +6,5 @@
   <maintainer email="todo@example.com">TODO</maintainer>
   <license>TODO</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>rostest</test_depend>
 </package>

--- a/catkin_ws/src/manipulation/test/sample_data.txt
+++ b/catkin_ws/src/manipulation/test/sample_data.txt
@@ -1,0 +1,1 @@
+sample data

--- a/catkin_ws/src/manipulation/test/test_basic.py
+++ b/catkin_ws/src/manipulation/test/test_basic.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+import unittest
+
+class BasicTest(unittest.TestCase):
+    def test_read_sample(self):
+        path = os.path.join(os.path.dirname(__file__), "sample_data.txt")
+        with open(path) as f:
+            data = f.read().strip()
+        self.assertEqual(data, "sample data")
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun('manipulation', 'basic_test', BasicTest)

--- a/catkin_ws/src/manipulation/test/test_basic.test
+++ b/catkin_ws/src/manipulation/test/test_basic.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="basic_test" pkg="manipulation" type="test_basic.py" />
+</launch>

--- a/catkin_ws/src/navigation/CMakeLists.txt
+++ b/catkin_ws/src/navigation/CMakeLists.txt
@@ -5,3 +5,8 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest(test/test_basic.test)
+endif()

--- a/catkin_ws/src/navigation/package.xml
+++ b/catkin_ws/src/navigation/package.xml
@@ -6,4 +6,5 @@
   <maintainer email="todo@example.com">TODO</maintainer>
   <license>TODO</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>rostest</test_depend>
 </package>

--- a/catkin_ws/src/navigation/test/sample_data.txt
+++ b/catkin_ws/src/navigation/test/sample_data.txt
@@ -1,0 +1,1 @@
+sample data

--- a/catkin_ws/src/navigation/test/test_basic.py
+++ b/catkin_ws/src/navigation/test/test_basic.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+import unittest
+
+class BasicTest(unittest.TestCase):
+    def test_read_sample(self):
+        path = os.path.join(os.path.dirname(__file__), "sample_data.txt")
+        with open(path) as f:
+            data = f.read().strip()
+        self.assertEqual(data, "sample data")
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun('navigation', 'basic_test', BasicTest)

--- a/catkin_ws/src/navigation/test/test_basic.test
+++ b/catkin_ws/src/navigation/test/test_basic.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="basic_test" pkg="navigation" type="test_basic.py" />
+</launch>

--- a/catkin_ws/src/perception/CMakeLists.txt
+++ b/catkin_ws/src/perception/CMakeLists.txt
@@ -5,3 +5,8 @@ catkin_package()
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest(test/test_basic.test)
+endif()

--- a/catkin_ws/src/perception/package.xml
+++ b/catkin_ws/src/perception/package.xml
@@ -6,4 +6,5 @@
   <maintainer email="todo@example.com">TODO</maintainer>
   <license>TODO</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <test_depend>rostest</test_depend>
 </package>

--- a/catkin_ws/src/perception/test/sample_data.txt
+++ b/catkin_ws/src/perception/test/sample_data.txt
@@ -1,0 +1,1 @@
+sample data

--- a/catkin_ws/src/perception/test/test_basic.py
+++ b/catkin_ws/src/perception/test/test_basic.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+import unittest
+
+class BasicTest(unittest.TestCase):
+    def test_read_sample(self):
+        path = os.path.join(os.path.dirname(__file__), "sample_data.txt")
+        with open(path) as f:
+            data = f.read().strip()
+        self.assertEqual(data, "sample data")
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun('perception', 'basic_test', BasicTest)

--- a/catkin_ws/src/perception/test/test_basic.test
+++ b/catkin_ws/src/perception/test/test_basic.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="basic_test" pkg="perception" type="test_basic.py" />
+</launch>


### PR DESCRIPTION
## Summary
- add minimal rostest infrastructure for interfaces, manipulation, navigation and perception packages
- include sample data files for tests
- ensure tests run in CI via `catkin_make run_tests`

## Testing
- `catkin_make run_tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f2862b448329874b0821ef6c54a7