### PR TITLE
Add project board overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,8 @@ If you need to add large binary assets, please use
 [Git LFS](https://git-lfs.github.com/) to store them. This keeps the repository
 size manageable.
 
+## Project Board
+The [project board](docs/project_board.md) lists open issues and labels such as
+`phase1`, `phase2`, `doc`, `infra`, and `good-first-issue`. Check the board to
+claim tasks or see what's planned for upcoming milestones.
+

--- a/docs/project_board.md
+++ b/docs/project_board.md
@@ -1,0 +1,21 @@
+# Project Board
+
+This repository tracks new features and cleanup tasks on the GitHub project board. The following labels help organize work:
+
+- `phase1` – foundational tasks for the first milestone
+- `phase2` – work scheduled for later milestones
+- `doc` – documentation updates
+- `infra` – tooling and build infrastructure
+- `good-first-issue` – straightforward tasks for new contributors
+
+## Initial Issues
+
+The project board currently includes these starter issues:
+
+1. **Replace binary PDFs with links** – convert the vendor lesson PDFs to web links (`phase1`, `doc`, `good-first-issue`).
+2. **Implement `camera_driver_node`** – create a ROS node to publish camera frames (`phase1`, `infra`).
+3. **Draft `ARCHITECTURE.md`** – outline the ROS nodes and data flow (`phase1`, `doc`).
+4. **Define `PickPlaceAction`** – specify an action interface for object handling (`phase2`, `infra`).
+5. **Add a VS Code dev container** – configure `.devcontainer` for consistent setups (`phase2`, `infra`).
+
+Contributors can browse the board to claim issues and track progress.


### PR DESCRIPTION
## Summary
- describe common labels and starter issues in `docs/project_board.md`
- reference the board from the contributing guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f28749d48329984a6111a3d807a8